### PR TITLE
Add the deps to light as well

### DIFF
--- a/rules.bzl
+++ b/rules.bzl
@@ -38,7 +38,7 @@ def _pkg_msi_impl(ctx):
 
     ctx.actions.run(
         outputs = [out],
-        inputs = [obj],
+        inputs = [obj] + my_deps,
         executable = ctx.executable._light,
         arguments = ["-nologo"] + exts + ["-out", out.path, obj.path],
     )


### PR DESCRIPTION
Earlier the deps were only added to Candle, which caused an issue when even though the binary changed, the MSI was not picking it up.

This change fixes the issue by adding my_deps as input to Light as well. I verified locally by creating a go binary whose changes are picked by the MSI.